### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Jodre11/secret-message-decoder/security/code-scanning/1](https://github.com/Jodre11/secret-message-decoder/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read-only operations (e.g., installing dependencies, running tests, and linting), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
